### PR TITLE
Update to call Phonno v2 APIs

### DIFF
--- a/phonno/phonnolet/v0/chat.py
+++ b/phonno/phonnolet/v0/chat.py
@@ -16,7 +16,7 @@ def similar_with(queries, topk=5, origin="", token=""):
             qs.append(q.strip())
     if len(qs) == 0:
         return [], []
-    api_url = "{}/api/chat/similar?q={}&limit={}".format(
+    api_url = "{}/api/v2/app/legacy/chat/similar?q={}&limit={}".format(
         origin,
         urllib.parse.quote(" ".join(qs)),
         topk,

--- a/phonno/phonnolet/v0/chat.py
+++ b/phonno/phonnolet/v0/chat.py
@@ -16,7 +16,7 @@ def similar_with(queries, topk=5, origin="", token=""):
             qs.append(q.strip())
     if len(qs) == 0:
         return [], []
-    api_url = "{}/api/v2/app/legacy/chat/similar?q={}&limit={}".format(
+    api_url = "{}/api/chat/similar?q={}&limit={}".format(
         origin,
         urllib.parse.quote(" ".join(qs)),
         topk,

--- a/phonno/phonnolet/v0/render.py
+++ b/phonno/phonnolet/v0/render.py
@@ -186,7 +186,7 @@ def show_annotations(
             if isinstance(item, list):
                 [image_id, anno_id, metadata] = item
                 url = "{}/{}/{}#a{}".format(origin, app_name, image_id, int(anno_id) + 1)
-                img_url = "{}/api/data/annotations_images?imageId={}&annoId={}".format(
+                img_url = "{}/api/v2/legacy/data/annotations_images?imageId={}&annoId={}".format(
                     origin, image_id, str(anno_id)
                 )
                 html_lines.append(
@@ -206,7 +206,7 @@ def show_annotations(
                 img_url = "{}/{}/thumb/300".format(img_origin, image_id)
             else:
                 url = "{}/{}/{}#a{}".format(origin, app_name, image_id, int(anno_id) + 1)
-                img_url = "{}/api/data/annotations_images?imageId={}&annoId={}".format(
+                img_url = "{}/api/v2/legacy/data/annotations_images?imageId={}&annoId={}".format(
                     origin, image_id, str(anno_id)
                 )
 

--- a/phonno/phonnolet/v0/search.py
+++ b/phonno/phonnolet/v0/search.py
@@ -6,7 +6,7 @@ def run_search(queries, origin="", token=""):
         return []
     if not token:
         raise Exception("No token provided")
-    api_url = "{}/api/similar".format(origin)
+    api_url = "{}/api/v2/legacy/similar".format(origin)
     headers = {
         "Content-Type": "application/json",
         "Accept": "application/json",

--- a/phonno/phonnolet/v0/search.py
+++ b/phonno/phonnolet/v0/search.py
@@ -7,7 +7,6 @@ def run_search(queries, origin="", token=""):
     if not token:
         raise Exception("No token provided")
     api_url = "{}/api/v2/legacy/similar".format(origin)
-    print("....", api_url)
     headers = {
         "Content-Type": "application/json",
         "Accept": "application/json",

--- a/phonno/phonnolet/v0/search.py
+++ b/phonno/phonnolet/v0/search.py
@@ -7,6 +7,7 @@ def run_search(queries, origin="", token=""):
     if not token:
         raise Exception("No token provided")
     api_url = "{}/api/v2/legacy/similar".format(origin)
+    print("....", api_url)
     headers = {
         "Content-Type": "application/json",
         "Accept": "application/json",


### PR DESCRIPTION
This pull request includes updates to API endpoint URLs in several methods across different files to use the new versioned paths. The changes ensure that the application uses the updated API endpoints for better compatibility and future-proofing.

API endpoint updates:

* [`phonno/phonnolet/v0/chat.py`](diffhunk://#diff-e68c7c4be894c6c877d509e4cddfd953b6d912ed4c37e75a83a262ee45e5e7a7L19-R19): Updated the `api_url` in the `similar_with` method to use the new versioned path `/api/v2/app/legacy/chat/similar`.
* [`phonno/phonnolet/v0/render.py`](diffhunk://#diff-0e3f6740c1681129f7c48d5de2e3852bf1a8b2456f767c15a80d562411239596L189-R189): Updated the `img_url` in the `show_annotations` method to use the new versioned path `/api/v2/legacy/data/annotations_images` in two places. [[1]](diffhunk://#diff-0e3f6740c1681129f7c48d5de2e3852bf1a8b2456f767c15a80d562411239596L189-R189) [[2]](diffhunk://#diff-0e3f6740c1681129f7c48d5de2e3852bf1a8b2456f767c15a80d562411239596L209-R209)
* [`phonno/phonnolet/v0/search.py`](diffhunk://#diff-67622cddce50f7c28445dd4cbe84f2778516f433949ef39ac058ca21776fd5d3L9-R9): Updated the `api_url` in the `run_search` method to use the new versioned path `/api/v2/legacy/similar`.