### PR TITLE
Deprecate project_name and merge it into app_name

### DIFF
--- a/phonno/phonnolet/v0/chat.py
+++ b/phonno/phonnolet/v0/chat.py
@@ -1,7 +1,7 @@
 import urllib, requests
 
 
-def similar_with(queries, topk=5, origin="", token=""):
+def similar_with(queries, topk=5, origin="", app_name="", token=""):
     if not token:
         raise Exception("No token provided")
     qs = []
@@ -16,8 +16,9 @@ def similar_with(queries, topk=5, origin="", token=""):
             qs.append(q.strip())
     if len(qs) == 0:
         return [], []
-    api_url = "{}/api/v2/app/legacy/chat/similar?q={}&limit={}".format(
+    api_url = "{}/api/v2/app/{}/chat/similar?q={}&limit={}".format(
         origin,
+        app_name,
         urllib.parse.quote(" ".join(qs)),
         topk,
     )

--- a/phonno/phonnolet/v0/render.py
+++ b/phonno/phonnolet/v0/render.py
@@ -186,8 +186,8 @@ def show_annotations(
             if isinstance(item, list):
                 [image_id, anno_id, metadata] = item
                 url = "{}/{}/{}#a{}".format(origin, app_name, image_id, int(anno_id) + 1)
-                img_url = "{}/api/v2/legacy/data/annotations_images?imageId={}&annoId={}".format(
-                    origin, image_id, str(anno_id)
+                img_url = "{}/api/v2/{}/data/annotations_images?imageId={}&annoId={}".format(
+                    origin, app_name, image_id, str(anno_id)
                 )
                 html_lines.append(
                     "<a href='{}' target='_blank'><img src='{}' style='{}' /></a>".format(
@@ -206,8 +206,8 @@ def show_annotations(
                 img_url = "{}/{}/thumb/300".format(img_origin, image_id)
             else:
                 url = "{}/{}/{}#a{}".format(origin, app_name, image_id, int(anno_id) + 1)
-                img_url = "{}/api/v2/legacy/data/annotations_images?imageId={}&annoId={}".format(
-                    origin, image_id, str(anno_id)
+                img_url = "{}/api/v2/{}/data/annotations_images?imageId={}&annoId={}".format(
+                    origin, app_name, image_id, str(anno_id)
                 )
 
             html_lines.append("<div data-name='annotation'>")  # 0

--- a/phonno/phonnolet/v0/render.py
+++ b/phonno/phonnolet/v0/render.py
@@ -172,7 +172,7 @@ def _get_anno_anchor_content_image_background_style(type, img_url):
 
 
 def show_annotations(
-    items, origin="", img_origin="", project_name="", app_name="", style="query", repeat_in_row=10, indent=False, theme=""
+    items, origin="", img_origin="", app_name="", style="query", repeat_in_row=10, indent=False, theme=""
 ):
     root_style = _get_anno_container_style(style, indent, repeat_in_row)
     img_style = _get_anno_img_style(style)
@@ -246,7 +246,7 @@ def show_annotations(
     IPython.display.display(IPython.display.HTML(html_str))
 
 
-def show_images(image_ids, origin="", project_name="", app_name="", repeat_in_row=6, indent=False, theme=""):
+def show_images(image_ids, origin="", app_name="", repeat_in_row=6, indent=False, theme=""):
     img_origin = "https://gyazo.com"
     items = []
     for image_id in image_ids:
@@ -256,7 +256,6 @@ def show_images(image_ids, origin="", project_name="", app_name="", repeat_in_ro
         items,
         origin=origin,
         img_origin=img_origin,
-        project_name=project_name,
         app_name=app_name,
         style="result",
         repeat_in_row=repeat_in_row,
@@ -265,7 +264,7 @@ def show_images(image_ids, origin="", project_name="", app_name="", repeat_in_ro
     )
 
 
-def show_chat(data, origin="", project_name="", app_name="", q=False, a=False, theme=""):
+def show_chat(data, origin="", app_name="", q=False, a=False, theme=""):
     chat_id = data["chatId"]
     chat_uri = "{}/share/{}".format(origin, chat_id)
     IPython.display.display(
@@ -280,7 +279,7 @@ def show_chat(data, origin="", project_name="", app_name="", q=False, a=False, t
                 query.append([item["imageId"], int(item["annoId"])])
             elif item["type"] == "text":
                 query.append(item["text"])
-        show_annotations(query, origin=origin, project_name=project_name, app_name=app_name, style="query", indent=True, theme=theme)
+        show_annotations(query, origin=origin, app_name=app_name, style="query", indent=True, theme=theme)
     if a:
         html_lines = []
         html_lines.append(
@@ -297,7 +296,7 @@ def show_chat(data, origin="", project_name="", app_name="", q=False, a=False, t
         for annoKey in data["hitDocs"].keys():
             anno = data["hitDocs"][annoKey]
             annos.append([anno["imageId"], int(anno["annoId"])])
-        show_annotations(annos, origin=origin, project_name=project_name, app_name=app_name, style="result", indent=True, theme=theme)
+        show_annotations(annos, origin=origin, app_name=app_name, style="result", indent=True, theme=theme)
 
     IPython.display.display(
         IPython.display.HTML(

--- a/phonno/phonnolet/v0/search.py
+++ b/phonno/phonnolet/v0/search.py
@@ -1,12 +1,12 @@
 import requests
 
 
-def run_search(queries, origin="", token=""):
+def run_search(queries, origin="", app_name="", token=""):
     if len(queries) == 0:
         return []
     if not token:
         raise Exception("No token provided")
-    api_url = "{}/api/v2/legacy/similar".format(origin)
+    api_url = "{}/api/v2/{}/similar".format(origin, app_name)
     headers = {
         "Content-Type": "application/json",
         "Accept": "application/json",


### PR DESCRIPTION
This pull request includes changes to add the `app_name` parameter to several functions across multiple files. The primary purpose of these changes is to ensure that API URLs are correctly formatted with the application name.

### Addition of `app_name` parameter:

* [`phonno/phonnolet/v0/chat.py`](diffhunk://#diff-e68c7c4be894c6c877d509e4cddfd953b6d912ed4c37e75a83a262ee45e5e7a7L4-R4): Added `app_name` parameter to the `similar_with` function and updated the API URL to include `app_name`. [[1]](diffhunk://#diff-e68c7c4be894c6c877d509e4cddfd953b6d912ed4c37e75a83a262ee45e5e7a7L4-R4) [[2]](diffhunk://#diff-e68c7c4be894c6c877d509e4cddfd953b6d912ed4c37e75a83a262ee45e5e7a7L19-R21)
* [`phonno/phonnolet/v0/render.py`](diffhunk://#diff-0e3f6740c1681129f7c48d5de2e3852bf1a8b2456f767c15a80d562411239596L175-R175): Added `app_name` parameter to the `show_annotations`, `show_images`, and `show_chat` functions. Updated the API URLs within these functions to include `app_name`. [[1]](diffhunk://#diff-0e3f6740c1681129f7c48d5de2e3852bf1a8b2456f767c15a80d562411239596L175-R175) [[2]](diffhunk://#diff-0e3f6740c1681129f7c48d5de2e3852bf1a8b2456f767c15a80d562411239596L189-R190) [[3]](diffhunk://#diff-0e3f6740c1681129f7c48d5de2e3852bf1a8b2456f767c15a80d562411239596L209-R210) [[4]](diffhunk://#diff-0e3f6740c1681129f7c48d5de2e3852bf1a8b2456f767c15a80d562411239596L249-R249) [[5]](diffhunk://#diff-0e3f6740c1681129f7c48d5de2e3852bf1a8b2456f767c15a80d562411239596L259) [[6]](diffhunk://#diff-0e3f6740c1681129f7c48d5de2e3852bf1a8b2456f767c15a80d562411239596L268-R267) [[7]](diffhunk://#diff-0e3f6740c1681129f7c48d5de2e3852bf1a8b2456f767c15a80d562411239596L283-R282) [[8]](diffhunk://#diff-0e3f6740c1681129f7c48d5de2e3852bf1a8b2456f767c15a80d562411239596L300-R299)
* [`phonno/phonnolet/v0/search.py`](diffhunk://#diff-67622cddce50f7c28445dd4cbe84f2778516f433949ef39ac058ca21776fd5d3L4-R9): Added `app_name` parameter to the `run_search` function and updated the API URL to include `app_name`.